### PR TITLE
Document blob download safety limits

### DIFF
--- a/api-def/uniwebview.toml
+++ b/api-def/uniwebview.toml
@@ -3391,7 +3391,7 @@ summary = "The web view component which raises this event."
 [[Events.parameters]]
 name = "remoteUrl"
 type = "string"
-summary = "The remote URL of this download task. This is also the download URL for the task."
+summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload."
 [[Events.parameters]]
 name = "fileName"
 type = "string"
@@ -3431,7 +3431,7 @@ an `ERROR_*` value in `DownloadManager`.
 [[Events.parameters]]
 name = "remoteUrl"
 type = "string"
-summary = "The remote URL of this download task."
+summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload."
 [[Events.parameters]]
 name = "diskPath"
 type = "string"

--- a/api-def/uniwebview.toml
+++ b/api-def/uniwebview.toml
@@ -2918,6 +2918,7 @@ Enables or disables the automatic download when a response cannot be rendered in
 When set to `false`, UniWebView skips starting a download task for non-renderable resources (such as attachments with
 unsupported MIME types). On iOS and macOS Editor, downloads triggered through `AddDownloadURL` or `AddDownloadMIMEType`
 still work. On Android, this prevents the download listener from forwarding unsupported resources to `DownloadManager`.
+Data and blob URLs are ignored on all platforms while automatic downloading is disabled.
 """
 [[Methods.parameters]]
 name = "enabled"

--- a/api-def/uniwebview.toml
+++ b/api-def/uniwebview.toml
@@ -3391,7 +3391,7 @@ summary = "The web view component which raises this event."
 [[Events.parameters]]
 name = "remoteUrl"
 type = "string"
-summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload."
+summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload. For a blob URL download, this is the `blob:` URL that started the task."
 [[Events.parameters]]
 name = "fileName"
 type = "string"
@@ -3431,7 +3431,7 @@ an `ERROR_*` value in `DownloadManager`.
 [[Events.parameters]]
 name = "remoteUrl"
 type = "string"
-summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload."
+summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload. For a blob URL download, this is the `blob:` URL that started the task."
 [[Events.parameters]]
 name = "diskPath"
 type = "string"

--- a/docs/.vuepress/public/api/uniwebview.toml
+++ b/docs/.vuepress/public/api/uniwebview.toml
@@ -2918,6 +2918,7 @@ Enables or disables the automatic download when a response cannot be rendered in
 When set to `false`, UniWebView skips starting a download task for non-renderable resources (such as attachments with
 unsupported MIME types). On iOS and macOS Editor, downloads triggered through `AddDownloadURL` or `AddDownloadMIMEType`
 still work. On Android, this prevents the download listener from forwarding unsupported resources to `DownloadManager`.
+Data and blob URLs are ignored on all platforms while automatic downloading is disabled.
 """
 [[Methods.parameters]]
 name = "enabled"
@@ -3390,7 +3391,7 @@ summary = "The web view component which raises this event."
 [[Events.parameters]]
 name = "remoteUrl"
 type = "string"
-summary = "The remote URL of this download task. This is also the download URL for the task."
+summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload."
 [[Events.parameters]]
 name = "fileName"
 type = "string"
@@ -3430,7 +3431,7 @@ an `ERROR_*` value in `DownloadManager`.
 [[Events.parameters]]
 name = "remoteUrl"
 type = "string"
-summary = "The remote URL of this download task."
+summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload."
 [[Events.parameters]]
 name = "diskPath"
 type = "string"

--- a/docs/.vuepress/public/api/uniwebview.toml
+++ b/docs/.vuepress/public/api/uniwebview.toml
@@ -3391,7 +3391,7 @@ summary = "The web view component which raises this event."
 [[Events.parameters]]
 name = "remoteUrl"
 type = "string"
-summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload."
+summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload. For a blob URL download, this is the `blob:` URL that started the task."
 [[Events.parameters]]
 name = "fileName"
 type = "string"
@@ -3431,7 +3431,7 @@ an `ERROR_*` value in `DownloadManager`.
 [[Events.parameters]]
 name = "remoteUrl"
 type = "string"
-summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload."
+summary = "The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload. For a blob URL download, this is the `blob:` URL that started the task."
 [[Events.parameters]]
 name = "diskPath"
 type = "string"

--- a/docs/.vuepress/public/guide/download-files.md
+++ b/docs/.vuepress/public/guide/download-files.md
@@ -18,7 +18,7 @@ webView.SetAutoDownloadEnabled(false);
 When disabled, UniWebView ignores those non-renderable responses. On iOS and macOS Editor, any URLs or MIME types you
 explicitly add through `AddDownloadURL` or `AddDownloadMIMEType` still trigger downloads. On Android, this prevents the
 underlying download listener from forwarding the request to `DownloadManager`. Context menu actions like “Save Image” are
-not affected.
+not affected. Data and blob URLs are also ignored while automatic downloading is disabled.
 
 ## Android
 
@@ -132,6 +132,13 @@ If you need to handle these errors, write code for different cases for different
 ## Data Link and Blob Link
 
 UniWebView supports downloading from [data link](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data) and [blob link](https://developer.mozilla.org/en-US/docs/Web/API/Blob). A system alert dialog will be presented to the user to decide the download file name and post-download action.
+
+Data and blob downloads are limited to 16 MiB of decoded content. Data URLs are parsed with a bounded decoder. For blob
+URLs, UniWebView rejects oversized responses and blobs before converting them to a base64 data URI for the JavaScript-to-native
+bridge. Use a regular HTTP(S) download URL for larger files.
+
+For data downloads, `OnFileDownloadStarted` and `OnFileDownloadFinished` receive only the URI metadata through the
+comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity.
 
 When dealing with blob link, UniWebView will try to fetch the content of the blob link. You need to make sure the blob link is available during the loading. That means, you should not call the `URL.revokeObjectURL(blobURL);` in your JavaScript too early. A possible and naive way to handle this is delaying the revoking call for a while:
 

--- a/docs/.vuepress/public/guide/download-files.md
+++ b/docs/.vuepress/public/guide/download-files.md
@@ -138,7 +138,14 @@ URLs, UniWebView rejects oversized responses and blobs before converting them to
 bridge. Use a regular HTTP(S) download URL for larger files.
 
 For data downloads, `OnFileDownloadStarted` and `OnFileDownloadFinished` receive only the URI metadata through the
-comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity.
+comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity. For blob
+downloads, `remoteUrl` is the `blob:` URL that started the download on all platforms. Percent-encoded data URL payloads
+are decoded following RFC 2397: a literal `+` stays a plus sign instead of being converted to a space.
+
+Blob downloads are only handled when they are initiated from the main frame, including links that open a new window
+from the main frame. Blob navigations started inside an embedded frame are ignored. The blob bridge also requires a
+native-issued, one-time request token for each download, so page scripts cannot trigger download events or file writes
+without an actual blob download being started. Data URL downloads are not frame-restricted.
 
 When dealing with blob link, UniWebView will try to fetch the content of the blob link. You need to make sure the blob link is available during the loading. That means, you should not call the `URL.revokeObjectURL(blobURL);` in your JavaScript too early. A possible and naive way to handle this is delaying the revoking call for a while:
 

--- a/docs/.vuepress/public/llms-full.txt
+++ b/docs/.vuepress/public/llms-full.txt
@@ -1159,7 +1159,7 @@ webView.SetAutoDownloadEnabled(false);
 When disabled, UniWebView ignores those non-renderable responses. On iOS and macOS Editor, any URLs or MIME types you
 explicitly add through `AddDownloadURL` or `AddDownloadMIMEType` still trigger downloads. On Android, this prevents the
 underlying download listener from forwarding the request to `DownloadManager`. Context menu actions like “Save Image” are
-not affected.
+not affected. Data and blob URLs are also ignored while automatic downloading is disabled.
 
 ## Android
 
@@ -1273,6 +1273,13 @@ If you need to handle these errors, write code for different cases for different
 ## Data Link and Blob Link
 
 UniWebView supports downloading from [data link](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data) and [blob link](https://developer.mozilla.org/en-US/docs/Web/API/Blob). A system alert dialog will be presented to the user to decide the download file name and post-download action.
+
+Data and blob downloads are limited to 16 MiB of decoded content. Data URLs are parsed with a bounded decoder. For blob
+URLs, UniWebView rejects oversized responses and blobs before converting them to a base64 data URI for the JavaScript-to-native
+bridge. Use a regular HTTP(S) download URL for larger files.
+
+For data downloads, `OnFileDownloadStarted` and `OnFileDownloadFinished` receive only the URI metadata through the
+comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity.
 
 When dealing with blob link, UniWebView will try to fetch the content of the blob link. You need to make sure the blob link is available during the loading. That means, you should not call the `URL.revokeObjectURL(blobURL);` in your JavaScript too early. A possible and naive way to handle this is delaying the revoking call for a while:
 
@@ -12068,6 +12075,7 @@ Enables or disables the automatic download when a response cannot be rendered in
 When set to `false`, UniWebView skips starting a download task for non-renderable resources (such as attachments with
 unsupported MIME types). On iOS and macOS Editor, downloads triggered through `AddDownloadURL` or `AddDownloadMIMEType`
 still work. On Android, this prevents the download listener from forwarding unsupported resources to `DownloadManager`.
+Data and blob URLs are ignored on all platforms while automatic downloading is disabled.
 
 [[Methods.parameters]]
 name: enabled
@@ -12567,7 +12575,7 @@ summary: The web view component which raises this event.
 [[Events.parameters]]
 name: remoteUrl
 type: string
-summary: The remote URL of this download task. This is also the download URL for the task.
+summary: The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload.
 [[Events.parameters]]
 name: fileName
 type: string
@@ -12610,7 +12618,7 @@ an `ERROR_*` value in `DownloadManager`.
 [[Events.parameters]]
 name: remoteUrl
 type: string
-summary: The remote URL of this download task.
+summary: The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload.
 [[Events.parameters]]
 name: diskPath
 type: string

--- a/docs/.vuepress/public/llms-full.txt
+++ b/docs/.vuepress/public/llms-full.txt
@@ -1279,7 +1279,14 @@ URLs, UniWebView rejects oversized responses and blobs before converting them to
 bridge. Use a regular HTTP(S) download URL for larger files.
 
 For data downloads, `OnFileDownloadStarted` and `OnFileDownloadFinished` receive only the URI metadata through the
-comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity.
+comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity. For blob
+downloads, `remoteUrl` is the `blob:` URL that started the download on all platforms. Percent-encoded data URL payloads
+are decoded following RFC 2397: a literal `+` stays a plus sign instead of being converted to a space.
+
+Blob downloads are only handled when they are initiated from the main frame, including links that open a new window
+from the main frame. Blob navigations started inside an embedded frame are ignored. The blob bridge also requires a
+native-issued, one-time request token for each download, so page scripts cannot trigger download events or file writes
+without an actual blob download being started. Data URL downloads are not frame-restricted.
 
 When dealing with blob link, UniWebView will try to fetch the content of the blob link. You need to make sure the blob link is available during the loading. That means, you should not call the `URL.revokeObjectURL(blobURL);` in your JavaScript too early. A possible and naive way to handle this is delaying the revoking call for a while:
 
@@ -12575,7 +12582,7 @@ summary: The web view component which raises this event.
 [[Events.parameters]]
 name: remoteUrl
 type: string
-summary: The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload.
+summary: The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload. For a blob URL download, this is the `blob:` URL that started the task.
 [[Events.parameters]]
 name: fileName
 type: string
@@ -12618,7 +12625,7 @@ an `ERROR_*` value in `DownloadManager`.
 [[Events.parameters]]
 name: remoteUrl
 type: string
-summary: The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload.
+summary: The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload. For a blob URL download, this is the `blob:` URL that started the task.
 [[Events.parameters]]
 name: diskPath
 type: string

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1014,7 +1014,7 @@ webView<span class="token punctuation">.</span><span class="token function">Capt
   </li>
   <li>
     <div class='parameter-item'><span class='parameter-item-type'>string</span> <span class='parameter-item-name'>remoteUrl</span></div>
-    <div class='parameter-item-desc'><p>The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload.</p>
+    <div class='parameter-item-desc'><p>The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload. For a blob URL download, this is the <code>blob:</code> URL that started the task.</p>
 </div>
   </li>
   <li>
@@ -1061,7 +1061,7 @@ an <code>ERROR_*</code> value in <code>DownloadManager</code>.</p>
   </li>
   <li>
     <div class='parameter-item'><span class='parameter-item-type'>string</span> <span class='parameter-item-name'>remoteUrl</span></div>
-    <div class='parameter-item-desc'><p>The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload.</p>
+    <div class='parameter-item-desc'><p>The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload. For a blob URL download, this is the <code>blob:</code> URL that started the task.</p>
 </div>
   </li>
   <li>

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1014,7 +1014,7 @@ webView<span class="token punctuation">.</span><span class="token function">Capt
   </li>
   <li>
     <div class='parameter-item'><span class='parameter-item-type'>string</span> <span class='parameter-item-name'>remoteUrl</span></div>
-    <div class='parameter-item-desc'><p>The remote URL of this download task. This is also the download URL for the task.</p>
+    <div class='parameter-item-desc'><p>The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload.</p>
 </div>
   </li>
   <li>
@@ -1061,7 +1061,7 @@ an <code>ERROR_*</code> value in <code>DownloadManager</code>.</p>
   </li>
   <li>
     <div class='parameter-item'><span class='parameter-item-type'>string</span> <span class='parameter-item-name'>remoteUrl</span></div>
-    <div class='parameter-item-desc'><p>The remote URL of this download task.</p>
+    <div class='parameter-item-desc'><p>The remote URL of this download task. For a data URL, this contains only the URI metadata through the comma and does not include the embedded payload.</p>
 </div>
   </li>
   <li>
@@ -5077,7 +5077,8 @@ used.</p>
 <p>Enables or disables the automatic download when a response cannot be rendered in the web view. Default is <code>true</code>.</p>
 <p>When set to <code>false</code>, UniWebView skips starting a download task for non-renderable resources (such as attachments with
 unsupported MIME types). On iOS and macOS Editor, downloads triggered through <code>AddDownloadURL</code> or <code>AddDownloadMIMEType</code>
-still work. On Android, this prevents the download listener from forwarding unsupported resources to <code>DownloadManager</code>.</p>
+still work. On Android, this prevents the download listener from forwarding unsupported resources to <code>DownloadManager</code>.
+Data and blob URLs are ignored on all platforms while automatic downloading is disabled.</p>
 </div>
             <div class='parameters'>
 <div class='section-title'>Parameters</div>

--- a/docs/guide/download-files.md
+++ b/docs/guide/download-files.md
@@ -133,9 +133,9 @@ If you need to handle these errors, write code for different cases for different
 
 UniWebView supports downloading from [data link](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data) and [blob link](https://developer.mozilla.org/en-US/docs/Web/API/Blob). A system alert dialog will be presented to the user to decide the download file name and post-download action.
 
-Data and blob downloads are limited to 16 MiB of decoded content. These URLs are transferred through the JavaScript-to-native
-bridge as an in-memory data URI, so larger payloads are rejected before base64 decoding to avoid excessive memory use. Use a
-regular HTTP(S) download URL for larger files.
+Data and blob downloads are limited to 16 MiB of decoded content. Data URLs are parsed with a bounded decoder. For blob
+URLs, UniWebView rejects oversized responses and blobs before converting them to a base64 data URI for the JavaScript-to-native
+bridge. Use a regular HTTP(S) download URL for larger files.
 
 When dealing with blob link, UniWebView will try to fetch the content of the blob link. You need to make sure the blob link is available during the loading. That means, you should not call the `URL.revokeObjectURL(blobURL);` in your JavaScript too early. A possible and naive way to handle this is delaying the revoking call for a while:
 

--- a/docs/guide/download-files.md
+++ b/docs/guide/download-files.md
@@ -18,7 +18,7 @@ webView.SetAutoDownloadEnabled(false);
 When disabled, UniWebView ignores those non-renderable responses. On iOS and macOS Editor, any URLs or MIME types you
 explicitly add through `AddDownloadURL` or `AddDownloadMIMEType` still trigger downloads. On Android, this prevents the
 underlying download listener from forwarding the request to `DownloadManager`. Context menu actions like “Save Image” are
-not affected.
+not affected. Data and blob URLs are also ignored while automatic downloading is disabled.
 
 ## Android
 
@@ -132,6 +132,10 @@ If you need to handle these errors, write code for different cases for different
 ## Data Link and Blob Link
 
 UniWebView supports downloading from [data link](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data) and [blob link](https://developer.mozilla.org/en-US/docs/Web/API/Blob). A system alert dialog will be presented to the user to decide the download file name and post-download action.
+
+Data and blob downloads are limited to 16 MiB of decoded content. These URLs are transferred through the JavaScript-to-native
+bridge as an in-memory data URI, so larger payloads are rejected before base64 decoding to avoid excessive memory use. Use a
+regular HTTP(S) download URL for larger files.
 
 When dealing with blob link, UniWebView will try to fetch the content of the blob link. You need to make sure the blob link is available during the loading. That means, you should not call the `URL.revokeObjectURL(blobURL);` in your JavaScript too early. A possible and naive way to handle this is delaying the revoking call for a while:
 

--- a/docs/guide/download-files.md
+++ b/docs/guide/download-files.md
@@ -138,7 +138,14 @@ URLs, UniWebView rejects oversized responses and blobs before converting them to
 bridge. Use a regular HTTP(S) download URL for larger files.
 
 For data downloads, `OnFileDownloadStarted` and `OnFileDownloadFinished` receive only the URI metadata through the
-comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity.
+comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity. For blob
+downloads, `remoteUrl` is the `blob:` URL that started the download on all platforms. Percent-encoded data URL payloads
+are decoded following RFC 2397: a literal `+` stays a plus sign instead of being converted to a space.
+
+Blob downloads are only handled when they are initiated from the main frame, including links that open a new window
+from the main frame. Blob navigations started inside an embedded frame are ignored. The blob bridge also requires a
+native-issued, one-time request token for each download, so page scripts cannot trigger download events or file writes
+without an actual blob download being started. Data URL downloads are not frame-restricted.
 
 When dealing with blob link, UniWebView will try to fetch the content of the blob link. You need to make sure the blob link is available during the loading. That means, you should not call the `URL.revokeObjectURL(blobURL);` in your JavaScript too early. A possible and naive way to handle this is delaying the revoking call for a while:
 

--- a/docs/guide/download-files.md
+++ b/docs/guide/download-files.md
@@ -137,6 +137,9 @@ Data and blob downloads are limited to 16 MiB of decoded content. Data URLs are 
 URLs, UniWebView rejects oversized responses and blobs before converting them to a base64 data URI for the JavaScript-to-native
 bridge. Use a regular HTTP(S) download URL for larger files.
 
+For data downloads, `OnFileDownloadStarted` and `OnFileDownloadFinished` receive only the URI metadata through the
+comma (for example, `data:image/png;base64,`) as `remoteUrl`. The embedded payload is not forwarded to Unity.
+
 When dealing with blob link, UniWebView will try to fetch the content of the blob link. You need to make sure the blob link is available during the loading. That means, you should not call the `URL.revokeObjectURL(blobURL);` in your JavaScript too early. A possible and naive way to handle this is delaying the revoking call for a while:
 
 ```javascript


### PR DESCRIPTION
## Summary

- document that disabling automatic downloads also blocks data and blob URLs
- document the 16 MiB decoded-content limit for in-memory data/blob downloads
- recommend regular HTTP(S) downloads for larger files

This accompanies the native bridge hardening in `onevcat/UniWebView`.
