### PR TITLE
Document Android public download destination

### DIFF
--- a/api-def/UniWebViewAndroidDownloadDestination.toml
+++ b/api-def/UniWebViewAndroidDownloadDestination.toml
@@ -1,0 +1,20 @@
+title = "UniWebViewAndroidDownloadDestination"
+file = "UniWebViewAndroidDownloadDestination"
+
+[[Properties]]
+name = "AppSpecific"
+returnType = "UniWebViewAndroidDownloadDestination"
+hasSetter = false
+summary = """
+Stores files in the app-specific external Downloads directory. This is the default. Files are removed when the app is
+uninstalled and may not be browsable from ordinary file manager apps on Android 11 and newer.
+"""
+
+[[Properties]]
+name = "PublicDownloads"
+returnType = "UniWebViewAndroidDownloadDestination"
+hasSetter = false
+summary = """
+Stores files in the user's public Downloads directory. Files remain after app uninstallation and are visible to the user
+and other apps.
+"""

--- a/api-def/uniwebview.toml
+++ b/api-def/uniwebview.toml
@@ -2934,6 +2934,37 @@ name = "Android"
 color = "green"
 
 [[Methods]]
+name = "SetAndroidDownloadDestination"
+syntax = "SetAndroidDownloadDestination(UniWebViewAndroidDownloadDestination destination)"
+returnType = "void"
+summary = """
+Sets the destination for files downloaded by this web view on Android. The default is `AppSpecific`.
+
+`AppSpecific` stores files in the app-specific external Downloads directory. `PublicDownloads` stores files in the user's
+public Downloads directory. This setting affects normal URL, data URL, blob URL, and context-menu image downloads.
+
+On Android 10 and newer, public Downloads uses `MediaStore` and needs no storage permission. The `diskPath` parameter in
+`OnFileDownloadFinished` is a `content://` URI for this destination. On Android 9 and older, public Downloads requires
+`WRITE_EXTERNAL_STORAGE` and its runtime permission; `diskPath` is a filesystem path.
+
+This method only works on Android.
+"""
+example = """
+```csharp
+webView.SetAndroidDownloadDestination(
+    UniWebViewAndroidDownloadDestination.PublicDownloads
+);
+```
+"""
+[[Methods.parameters]]
+name = "destination"
+type = "UniWebViewAndroidDownloadDestination"
+summary = "The destination used for subsequent downloads from this web view."
+[[Methods.badges]]
+name = "Android"
+color = "green"
+
+[[Methods]]
 name = "SetAllowUserChooseActionAfterDownloading"
 syntax = "SetAllowUserChooseActionAfterDownloading(bool allowed)"
 returnType = "void"
@@ -2969,9 +3000,8 @@ saving action triggered by the callout (context) menu on Android.
 
 By default, the image saving goes through a different route and it does not trigger the `OnFileDownloadStarted` 
 and `OnFileDownloadFinished` events like other normal download tasks. Setting this with enabled with `true` if
-you also need to get notified when user long-presses on the image and taps "Save Image" button. By default, the
-image will be saved to the Downloads directory and you can get the path from the parameter 
-of `OnFileDownloadFinished` event.
+you also need to get notified when user long-presses on the image and taps "Save Image" button. The image is saved
+to the configured Android download destination, and the location is provided by the `OnFileDownloadFinished` event.
 """
 notice = """
 This only works on Android. On iOS, there is no way to get a callback or any event from the "Add to Photos"
@@ -3435,8 +3465,9 @@ summary = "The remote URL of this download task."
 name = "diskPath"
 type = "string"
 summary = """
-The file path of the downloaded file. On iOS, the downloader file is in a temporary folder of your app sandbox.
-On Android, it is in the "Download" folder of your app.
+The location of the downloaded file. On iOS, the downloader file is in a temporary folder of your app sandbox.
+On Android, it is a filesystem path in the app-specific Downloads directory by default. When using
+`UniWebViewAndroidDownloadDestination.PublicDownloads` on Android 10 and newer, it is a `content://` URI instead.
 """
 
 [[Events]]

--- a/docs/.vuepress/public/api/UniWebViewAndroidDownloadDestination.toml
+++ b/docs/.vuepress/public/api/UniWebViewAndroidDownloadDestination.toml
@@ -1,0 +1,20 @@
+title = "UniWebViewAndroidDownloadDestination"
+file = "UniWebViewAndroidDownloadDestination"
+
+[[Properties]]
+name = "AppSpecific"
+returnType = "UniWebViewAndroidDownloadDestination"
+hasSetter = false
+summary = """
+Stores files in the app-specific external Downloads directory. This is the default. Files are removed when the app is
+uninstalled and may not be browsable from ordinary file manager apps on Android 11 and newer.
+"""
+
+[[Properties]]
+name = "PublicDownloads"
+returnType = "UniWebViewAndroidDownloadDestination"
+hasSetter = false
+summary = """
+Stores files in the user's public Downloads directory. Files remain after app uninstallation and are visible to the user
+and other apps.
+"""

--- a/docs/.vuepress/public/api/uniwebview.toml
+++ b/docs/.vuepress/public/api/uniwebview.toml
@@ -2934,6 +2934,37 @@ name = "Android"
 color = "green"
 
 [[Methods]]
+name = "SetAndroidDownloadDestination"
+syntax = "SetAndroidDownloadDestination(UniWebViewAndroidDownloadDestination destination)"
+returnType = "void"
+summary = """
+Sets the destination for files downloaded by this web view on Android. The default is `AppSpecific`.
+
+`AppSpecific` stores files in the app-specific external Downloads directory. `PublicDownloads` stores files in the user's
+public Downloads directory. This setting affects normal URL, data URL, blob URL, and context-menu image downloads.
+
+On Android 10 and newer, public Downloads uses `MediaStore` and needs no storage permission. The `diskPath` parameter in
+`OnFileDownloadFinished` is a `content://` URI for this destination. On Android 9 and older, public Downloads requires
+`WRITE_EXTERNAL_STORAGE` and its runtime permission; `diskPath` is a filesystem path.
+
+This method only works on Android.
+"""
+example = """
+```csharp
+webView.SetAndroidDownloadDestination(
+    UniWebViewAndroidDownloadDestination.PublicDownloads
+);
+```
+"""
+[[Methods.parameters]]
+name = "destination"
+type = "UniWebViewAndroidDownloadDestination"
+summary = "The destination used for subsequent downloads from this web view."
+[[Methods.badges]]
+name = "Android"
+color = "green"
+
+[[Methods]]
 name = "SetAllowUserChooseActionAfterDownloading"
 syntax = "SetAllowUserChooseActionAfterDownloading(bool allowed)"
 returnType = "void"
@@ -2969,9 +3000,8 @@ saving action triggered by the callout (context) menu on Android.
 
 By default, the image saving goes through a different route and it does not trigger the `OnFileDownloadStarted` 
 and `OnFileDownloadFinished` events like other normal download tasks. Setting this with enabled with `true` if
-you also need to get notified when user long-presses on the image and taps "Save Image" button. By default, the
-image will be saved to the Downloads directory and you can get the path from the parameter 
-of `OnFileDownloadFinished` event.
+you also need to get notified when user long-presses on the image and taps "Save Image" button. The image is saved
+to the configured Android download destination, and the location is provided by the `OnFileDownloadFinished` event.
 """
 notice = """
 This only works on Android. On iOS, there is no way to get a callback or any event from the "Add to Photos"
@@ -3435,8 +3465,9 @@ summary = "The remote URL of this download task."
 name = "diskPath"
 type = "string"
 summary = """
-The file path of the downloaded file. On iOS, the downloader file is in a temporary folder of your app sandbox.
-On Android, it is in the "Download" folder of your app.
+The location of the downloaded file. On iOS, the downloader file is in a temporary folder of your app sandbox.
+On Android, it is a filesystem path in the app-specific Downloads directory by default. When using
+`UniWebViewAndroidDownloadDestination.PublicDownloads` on Android 10 and newer, it is a `content://` URI instead.
 """
 
 [[Events]]

--- a/docs/.vuepress/public/guide/download-files.md
+++ b/docs/.vuepress/public/guide/download-files.md
@@ -22,9 +22,49 @@ not affected.
 
 ## Android
 
-For Android, there are not many configurable options.
+By default, UniWebView stores downloads in its app-specific external Downloads directory, typically:
 
-When accepting a resource that cannot be rendered, UniWebView will pop up a dialog asking the user for the file name they wish to use. By default, the file name will be read from the `Content-Disposition` header of the received response. After confirming the file name, the file will be stored in the app's `Download` folder. Users can find the downloaded file by accessing `Download` through the Notification Center banner or Android's File app.
+```text
+/storage/emulated/0/Android/data/<package-name>/files/Download
+```
+
+This is the `AppSpecific` destination. It applies to normal URL, data URL, blob URL, and context-menu image downloads.
+It does not require storage permission, is removed when the app is uninstalled, and may not be browsable from ordinary file
+manager apps on Android 11 and newer.
+
+To store downloads in the user's public Downloads directory instead, set the destination on the corresponding web view
+before starting a download:
+
+```csharp
+webView.SetAndroidDownloadDestination(
+    UniWebViewAndroidDownloadDestination.PublicDownloads
+);
+```
+
+This is an instance setting, so different web views can use different destinations. It affects all download types from that
+web view. Public Downloads files remain after app uninstallation and are visible to the user and other apps.
+
+On Android 10 and newer, UniWebView saves data and blob downloads through `MediaStore`; no storage permission is needed to
+create files owned by your app. In `OnFileDownloadFinished`, the `diskPath` value for this destination is a `content://` URI
+on these Android versions. Treat it as a content URI rather than a filesystem path.
+
+On Android 9 and older, public Downloads needs `WRITE_EXTERNAL_STORAGE`. Enable **Write External Storage** in the UniWebView
+Preferences panel to add it to the manifest, then request the runtime permission before starting a public download. The
+`diskPath` callback value is a filesystem path on these versions.
+
+```csharp
+#if UNITY_ANDROID && !UNITY_EDITOR
+if (!UnityEngine.Android.Permission.HasUserAuthorizedPermission(
+        UnityEngine.Android.Permission.ExternalStorageWrite)) {
+    UnityEngine.Android.Permission.RequestUserPermission(
+        UnityEngine.Android.Permission.ExternalStorageWrite
+    );
+}
+#endif
+```
+
+When accepting a resource that cannot be rendered, UniWebView will pop up a dialog asking the user for the file name they
+wish to use. By default, the file name will be read from the `Content-Disposition` header of the received response.
 
 ## iOS
 

--- a/docs/.vuepress/public/guide/installation.md
+++ b/docs/.vuepress/public/guide/installation.md
@@ -55,9 +55,11 @@ If you need to display plain HTTP content in the web view, turn it on.
 
 #### Write External Storage
 
-Add `WRITE_EXTERNAL_STORAGE` permission to the "AndroidManifest.xml". It enables storing an image from the web page to the Download folder on the device.
+Add `WRITE_EXTERNAL_STORAGE` permission to the `AndroidManifest.xml`. It is only required when using
+`UniWebViewAndroidDownloadDestination.PublicDownloads` on Android 9 and older; you must also request the runtime
+permission before starting the download.
 
-If you need to download and save any files to disk, turn it on.
+It is not required for the default app-specific Downloads destination or for public Downloads on Android 10 and newer.
 
 #### Access Fine Location
 

--- a/docs/.vuepress/public/llms-full.txt
+++ b/docs/.vuepress/public/llms-full.txt
@@ -1163,9 +1163,49 @@ not affected.
 
 ## Android
 
-For Android, there are not many configurable options.
+By default, UniWebView stores downloads in its app-specific external Downloads directory, typically:
 
-When accepting a resource that cannot be rendered, UniWebView will pop up a dialog asking the user for the file name they wish to use. By default, the file name will be read from the `Content-Disposition` header of the received response. After confirming the file name, the file will be stored in the app's `Download` folder. Users can find the downloaded file by accessing `Download` through the Notification Center banner or Android's File app.
+```text
+/storage/emulated/0/Android/data/<package-name>/files/Download
+```
+
+This is the `AppSpecific` destination. It applies to normal URL, data URL, blob URL, and context-menu image downloads.
+It does not require storage permission, is removed when the app is uninstalled, and may not be browsable from ordinary file
+manager apps on Android 11 and newer.
+
+To store downloads in the user's public Downloads directory instead, set the destination on the corresponding web view
+before starting a download:
+
+```csharp
+webView.SetAndroidDownloadDestination(
+    UniWebViewAndroidDownloadDestination.PublicDownloads
+);
+```
+
+This is an instance setting, so different web views can use different destinations. It affects all download types from that
+web view. Public Downloads files remain after app uninstallation and are visible to the user and other apps.
+
+On Android 10 and newer, UniWebView saves data and blob downloads through `MediaStore`; no storage permission is needed to
+create files owned by your app. In `OnFileDownloadFinished`, the `diskPath` value for this destination is a `content://` URI
+on these Android versions. Treat it as a content URI rather than a filesystem path.
+
+On Android 9 and older, public Downloads needs `WRITE_EXTERNAL_STORAGE`. Enable **Write External Storage** in the UniWebView
+Preferences panel to add it to the manifest, then request the runtime permission before starting a public download. The
+`diskPath` callback value is a filesystem path on these versions.
+
+```csharp
+#if UNITY_ANDROID && !UNITY_EDITOR
+if (!UnityEngine.Android.Permission.HasUserAuthorizedPermission(
+        UnityEngine.Android.Permission.ExternalStorageWrite)) {
+    UnityEngine.Android.Permission.RequestUserPermission(
+        UnityEngine.Android.Permission.ExternalStorageWrite
+    );
+}
+#endif
+```
+
+When accepting a resource that cannot be rendered, UniWebView will pop up a dialog asking the user for the file name they
+wish to use. By default, the file name will be read from the `Content-Disposition` header of the received response.
 
 ## iOS
 
@@ -1831,9 +1871,11 @@ If you need to display plain HTTP content in the web view, turn it on.
 
 #### Write External Storage
 
-Add `WRITE_EXTERNAL_STORAGE` permission to the "AndroidManifest.xml". It enables storing an image from the web page to the Download folder on the device.
+Add `WRITE_EXTERNAL_STORAGE` permission to the `AndroidManifest.xml`. It is only required when using
+`UniWebViewAndroidDownloadDestination.PublicDownloads` on Android 9 and older; you must also request the runtime
+permission before starting the download.
 
-If you need to download and save any files to disk, turn it on.
+It is not required for the default app-specific Downloads destination or for public Downloads on Android 10 and newer.
 
 #### Access Fine Location
 
@@ -5526,6 +5568,31 @@ summary:
 
 The body response of the access token exchange request. Usually it contains the desired `access_token` and other
 necessary fields to describe the authenticated result.
+
+---
+
+### UniWebViewAndroidDownloadDestination
+
+# UniWebViewAndroidDownloadDestination
+file: UniWebViewAndroidDownloadDestination
+
+[[Properties]]
+name: AppSpecific
+returnType: UniWebViewAndroidDownloadDestination
+hasSetter: false
+summary:
+
+Stores files in the app-specific external Downloads directory. This is the default. Files are removed when the app is
+uninstalled and may not be browsable from ordinary file manager apps on Android 11 and newer.
+
+[[Properties]]
+name: PublicDownloads
+returnType: UniWebViewAndroidDownloadDestination
+hasSetter: false
+summary:
+
+Stores files in the user's public Downloads directory. Files remain after app uninstallation and are visible to the user
+and other apps.
 
 ---
 
@@ -12084,6 +12151,39 @@ name: Android
 color: green
 
 [[Methods]]
+name: SetAndroidDownloadDestination
+syntax: SetAndroidDownloadDestination(UniWebViewAndroidDownloadDestination destination)
+returnType: void
+summary:
+
+Sets the destination for files downloaded by this web view on Android. The default is `AppSpecific`.
+
+`AppSpecific` stores files in the app-specific external Downloads directory. `PublicDownloads` stores files in the user's
+public Downloads directory. This setting affects normal URL, data URL, blob URL, and context-menu image downloads.
+
+On Android 10 and newer, public Downloads uses `MediaStore` and needs no storage permission. The `diskPath` parameter in
+`OnFileDownloadFinished` is a `content://` URI for this destination. On Android 9 and older, public Downloads requires
+`WRITE_EXTERNAL_STORAGE` and its runtime permission; `diskPath` is a filesystem path.
+
+This method only works on Android.
+
+example:
+
+```csharp
+webView.SetAndroidDownloadDestination(
+    UniWebViewAndroidDownloadDestination.PublicDownloads
+);
+```
+
+[[Methods.parameters]]
+name: destination
+type: UniWebViewAndroidDownloadDestination
+summary: The destination used for subsequent downloads from this web view.
+[[Methods.badges]]
+name: Android
+color: green
+
+[[Methods]]
 name: SetAllowUserChooseActionAfterDownloading
 syntax: SetAllowUserChooseActionAfterDownloading(bool allowed)
 returnType: void
@@ -12121,9 +12221,8 @@ saving action triggered by the callout (context) menu on Android.
 
 By default, the image saving goes through a different route and it does not trigger the `OnFileDownloadStarted` 
 and `OnFileDownloadFinished` events like other normal download tasks. Setting this with enabled with `true` if
-you also need to get notified when user long-presses on the image and taps "Save Image" button. By default, the
-image will be saved to the Downloads directory and you can get the path from the parameter 
-of `OnFileDownloadFinished` event.
+you also need to get notified when user long-presses on the image and taps "Save Image" button. The image is saved
+to the configured Android download destination, and the location is provided by the `OnFileDownloadFinished` event.
 
 notice:
 
@@ -12616,8 +12715,9 @@ name: diskPath
 type: string
 summary:
 
-The file path of the downloaded file. On iOS, the downloader file is in a temporary folder of your app sandbox.
-On Android, it is in the "Download" folder of your app.
+The location of the downloaded file. On iOS, the downloader file is in a temporary folder of your app sandbox.
+On Android, it is a filesystem path in the app-specific Downloads directory by default. When using
+`UniWebViewAndroidDownloadDestination.PublicDownloads` on Android 10 and newer, it is a `content://` URI instead.
 
 [[Events]]
 name: OnMessageReceived

--- a/docs/.vuepress/public/llms.txt
+++ b/docs/.vuepress/public/llms.txt
@@ -48,6 +48,7 @@
 ## API Reference
 
 - [IUniWebViewAuthenticationFlow](https://docs.uniwebview.com/api/IUniWebViewAuthenticationFlow.toml)
+- [UniWebViewAndroidDownloadDestination](https://docs.uniwebview.com/api/UniWebViewAndroidDownloadDestination.toml)
 - [UniWebViewAuthenticationCommonFlow](https://docs.uniwebview.com/api/UniWebViewAuthenticationCommonFlow.toml)
 - [UniWebViewAuthenticationFlowCustomize](https://docs.uniwebview.com/api/UniWebViewAuthenticationFlowCustomize.toml)
 - [UniWebViewAuthenticationFlowDiscord](https://docs.uniwebview.com/api/UniWebViewAuthenticationFlowDiscord.toml)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -414,6 +414,9 @@ HTTP authentication challenge (HTTP Basic or HTTP Digest) from server.</p>
 </td></tr><tr><td><div class='api-summary-heading'><a href='#setautodownloadenabled'><span class='return-type'>void</span> <span class='member-name'>SetAutoDownloadEnabled</span>(bool enabled)</a></div></td><td><div class='simple-summary'>
 <p>Enables or disables the automatic download when a response cannot be rendered in the web view.</p>
 </div>
+</td></tr><tr><td><div class='api-summary-heading'><a href='#setandroiddownloaddestination'><span class='return-type'>void</span> <span class='member-name'>SetAndroidDownloadDestination</span>(UniWebViewAndroidDownloadDestination destination)</a></div></td><td><div class='simple-summary'>
+<p>Sets the destination for files downloaded by this web view on Android.</p>
+</div>
 </td></tr><tr><td><div class='api-summary-heading'><a href='#setallowuserchooseactionafterdownloading'><span class='return-type'>void</span> <span class='member-name'>SetAllowUserChooseActionAfterDownloading</span>(bool allowed)</a></div></td><td><div class='simple-summary'>
 <p>Sets whether allowing users to choose the way to handle the downloaded file.</p>
 </div>
@@ -1066,8 +1069,9 @@ an <code>ERROR_*</code> value in <code>DownloadManager</code>.</p>
   </li>
   <li>
     <div class='parameter-item'><span class='parameter-item-type'>string</span> <span class='parameter-item-name'>diskPath</span></div>
-    <div class='parameter-item-desc'><p>The file path of the downloaded file. On iOS, the downloader file is in a temporary folder of your app sandbox.
-On Android, it is in the &quot;Download&quot; folder of your app.</p>
+    <div class='parameter-item-desc'><p>The location of the downloaded file. On iOS, the downloader file is in a temporary folder of your app sandbox.
+On Android, it is a filesystem path in the app-specific Downloads directory by default. When using
+<code>UniWebViewAndroidDownloadDestination.PublicDownloads</code> on Android 10 and newer, it is a <code>content://</code> URI instead.</p>
 </div>
   </li>
 </ul></div>
@@ -5093,6 +5097,41 @@ still work. On Android, this prevents the download listener from forwarding unsu
   </div>
 </div>
 <div class='api-box method'>
+  <div class="api-anchor" id='setandroiddownloaddestination'></div><div class='api-heading' data-id='setandroiddownloaddestination'><a href='#setandroiddownloaddestination'><span class='return-type'>void</span> <span class='member-name'>SetAndroidDownloadDestination</span>(UniWebViewAndroidDownloadDestination destination)</a><div class='api-badge api-badge-green'>Android</div></div>
+  <div class='api-body'>
+    <div class='desc'>
+      <div class='summary'>
+<p>Sets the destination for files downloaded by this web view on Android. The default is <code>AppSpecific</code>.</p>
+<p><code>AppSpecific</code> stores files in the app-specific external Downloads directory. <code>PublicDownloads</code> stores files in the user&#39;s
+public Downloads directory. This setting affects normal URL, data URL, blob URL, and context-menu image downloads.</p>
+<p>On Android 10 and newer, public Downloads uses <code>MediaStore</code> and needs no storage permission. The <code>diskPath</code> parameter in
+<code>OnFileDownloadFinished</code> is a <code>content://</code> URI for this destination. On Android 9 and older, public Downloads requires
+<code>WRITE_EXTERNAL_STORAGE</code> and its runtime permission; <code>diskPath</code> is a filesystem path.</p>
+<p>This method only works on Android.</p>
+</div>
+            <div class='parameters'>
+<div class='section-title'>Parameters</div>
+<div class='parameter-item-list'><ul>
+  <li>
+    <div class='parameter-item'><span class='parameter-item-type'>UniWebViewAndroidDownloadDestination</span> <span class='parameter-item-name'>destination</span></div>
+    <div class='parameter-item-desc'><p>The destination used for subsequent downloads from this web view.</p>
+</div>
+  </li>
+</ul></div>
+</div>
+            <div class='example'>
+    <p class='example-title'>Example</p>
+<div class="language-csharp extra-class">
+<pre class="language-csharp"><code>webView<span class="token punctuation">.</span><span class="token function">SetAndroidDownloadDestination</span><span class="token punctuation">(</span>
+    UniWebViewAndroidDownloadDestination<span class="token punctuation">.</span>PublicDownloads
+<span class="token punctuation">)</span><span class="token punctuation">;</span>
+</code></pre>
+</div>
+</div>
+    </div>
+  </div>
+</div>
+<div class='api-box method'>
   <div class="api-anchor" id='setallowuserchooseactionafterdownloading'></div><div class='api-heading' data-id='setallowuserchooseactionafterdownloading'><a href='#setallowuserchooseactionafterdownloading'><span class='return-type'>void</span> <span class='member-name'>SetAllowUserChooseActionAfterDownloading</span>(bool allowed)</a><div class='api-badge api-badge-orange'>iOS</div><div class='api-badge api-badge-purple'>macOS</div></div>
   <div class='api-body'>
     <div class='desc'>
@@ -5126,9 +5165,8 @@ File app or iCloud).</p>
 saving action triggered by the callout (context) menu on Android.</p>
 <p>By default, the image saving goes through a different route and it does not trigger the <code>OnFileDownloadStarted</code> 
 and <code>OnFileDownloadFinished</code> events like other normal download tasks. Setting this with enabled with <code>true</code> if
-you also need to get notified when user long-presses on the image and taps &quot;Save Image&quot; button. By default, the
-image will be saved to the Downloads directory and you can get the path from the parameter 
-of <code>OnFileDownloadFinished</code> event.</p>
+you also need to get notified when user long-presses on the image and taps &quot;Save Image&quot; button. The image is saved
+to the configured Android download destination, and the location is provided by the <code>OnFileDownloadFinished</code> event.</p>
 </div>
       <div class='custom-container warning'>
   <p class="custom-container-title">NOTICE</p>

--- a/docs/api/UniWebViewAndroidDownloadDestination.md
+++ b/docs/api/UniWebViewAndroidDownloadDestination.md
@@ -1,0 +1,45 @@
+---
+sidebarDepth: 0
+---
+
+## UniWebViewAndroidDownloadDestination
+
+### Summary
+
+#### Properties Summary
+
+<table class='api-summary-table api-summary-table--properties'>
+<colgroup><col class='api-summary-table__signature' /><col class='api-summary-table__description' /></colgroup>
+<tr><td><div class='api-summary-heading'><a href='#appspecific'><span class='return-type'>UniWebViewAndroidDownloadDestination</span> <span class='member-name'>AppSpecific</span> { get; }</a></div></td><td><div class='simple-summary'>
+<p>Stores files in the app-specific external Downloads directory.</p>
+</div>
+</td></tr><tr><td><div class='api-summary-heading'><a href='#publicdownloads'><span class='return-type'>UniWebViewAndroidDownloadDestination</span> <span class='member-name'>PublicDownloads</span> { get; }</a></div></td><td><div class='simple-summary'>
+<p>Stores files in the user&#39;s public Downloads directory.</p>
+</div>
+</td></tr></table>
+
+### Properties
+
+<div class='api-box property'>
+  <div class="api-anchor" id='appspecific'></div><div class='api-heading' data-id='appspecific'><a href='#appspecific'><span class='return-type'>UniWebViewAndroidDownloadDestination</span> <span class='member-name'>AppSpecific</span> { get; }</a></div>
+  <div class='api-body'>
+    <div class='desc'>
+      <div class='summary'>
+<p>Stores files in the app-specific external Downloads directory. This is the default. Files are removed when the app is
+uninstalled and may not be browsable from ordinary file manager apps on Android 11 and newer.</p>
+</div>
+                </div>
+  </div>
+</div>
+<div class='api-box property'>
+  <div class="api-anchor" id='publicdownloads'></div><div class='api-heading' data-id='publicdownloads'><a href='#publicdownloads'><span class='return-type'>UniWebViewAndroidDownloadDestination</span> <span class='member-name'>PublicDownloads</span> { get; }</a></div>
+  <div class='api-body'>
+    <div class='desc'>
+      <div class='summary'>
+<p>Stores files in the user&#39;s public Downloads directory. Files remain after app uninstallation and are visible to the user
+and other apps.</p>
+</div>
+                </div>
+  </div>
+</div>
+

--- a/docs/guide/download-files.md
+++ b/docs/guide/download-files.md
@@ -22,9 +22,49 @@ not affected.
 
 ## Android
 
-For Android, there are not many configurable options.
+By default, UniWebView stores downloads in its app-specific external Downloads directory, typically:
 
-When accepting a resource that cannot be rendered, UniWebView will pop up a dialog asking the user for the file name they wish to use. By default, the file name will be read from the `Content-Disposition` header of the received response. After confirming the file name, the file will be stored in the app's `Download` folder. Users can find the downloaded file by accessing `Download` through the Notification Center banner or Android's File app.
+```text
+/storage/emulated/0/Android/data/<package-name>/files/Download
+```
+
+This is the `AppSpecific` destination. It applies to normal URL, data URL, blob URL, and context-menu image downloads.
+It does not require storage permission, is removed when the app is uninstalled, and may not be browsable from ordinary file
+manager apps on Android 11 and newer.
+
+To store downloads in the user's public Downloads directory instead, set the destination on the corresponding web view
+before starting a download:
+
+```csharp
+webView.SetAndroidDownloadDestination(
+    UniWebViewAndroidDownloadDestination.PublicDownloads
+);
+```
+
+This is an instance setting, so different web views can use different destinations. It affects all download types from that
+web view. Public Downloads files remain after app uninstallation and are visible to the user and other apps.
+
+On Android 10 and newer, UniWebView saves data and blob downloads through `MediaStore`; no storage permission is needed to
+create files owned by your app. In `OnFileDownloadFinished`, the `diskPath` value for this destination is a `content://` URI
+on these Android versions. Treat it as a content URI rather than a filesystem path.
+
+On Android 9 and older, public Downloads needs `WRITE_EXTERNAL_STORAGE`. Enable **Write External Storage** in the UniWebView
+Preferences panel to add it to the manifest, then request the runtime permission before starting a public download. The
+`diskPath` callback value is a filesystem path on these versions.
+
+```csharp
+#if UNITY_ANDROID && !UNITY_EDITOR
+if (!UnityEngine.Android.Permission.HasUserAuthorizedPermission(
+        UnityEngine.Android.Permission.ExternalStorageWrite)) {
+    UnityEngine.Android.Permission.RequestUserPermission(
+        UnityEngine.Android.Permission.ExternalStorageWrite
+    );
+}
+#endif
+```
+
+When accepting a resource that cannot be rendered, UniWebView will pop up a dialog asking the user for the file name they
+wish to use. By default, the file name will be read from the `Content-Disposition` header of the received response.
 
 ## iOS
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -55,9 +55,11 @@ If you need to display plain HTTP content in the web view, turn it on.
 
 #### Write External Storage
 
-Add `WRITE_EXTERNAL_STORAGE` permission to the "AndroidManifest.xml". It enables storing an image from the web page to the Download folder on the device.
+Add `WRITE_EXTERNAL_STORAGE` permission to the `AndroidManifest.xml`. It is only required when using
+`UniWebViewAndroidDownloadDestination.PublicDownloads` on Android 9 and older; you must also request the runtime
+permission before starting the download.
 
-If you need to download and save any files to disk, turn it on.
+It is not required for the default app-specific Downloads destination or for public Downloads on Android 10 and newer.
 
 #### Access Fine Location
 


### PR DESCRIPTION
## Summary
- document app-specific Downloads as the default Android behavior
- document the opt-in public Downloads destination and its `content://` callback semantics
- document Android 9 and older permission requirements
- add the generated API reference for the new destination enum and instance method
